### PR TITLE
AssetNode: fix Maya 2018 support

### DIFF
--- a/AssetNode.C
+++ b/AssetNode.C
@@ -1843,11 +1843,12 @@ AssetNode::internalArrayCount(const MPlug &plug, const MDGContext &ctx) const
         return getAsset()->getAssetInfo().geoInputCount;
     }
 
-#if MAYA_API_VERSION >= 201800
-    return MPxTransform::internalArrayCount(plug);
-#else
+    /*
+     * Maya's headers may warn about calling a deprecated method here, but we
+     * cannot call MPxTransform::internalArrayCount(plug) instead because it
+     * will end up calling back internally into this method!
+     */
     return MPxTransform::internalArrayCount(plug, ctx);
-#endif
 }
 
 void


### PR DESCRIPTION
HoudiniEngine goes into an infinite loop calling internalArrayCount() in
Maya 2018.

Overload just one of the two methods, and use "using" to pull in the
base class implementation for the version that takes a context.